### PR TITLE
Sourcegenerator only run when not referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ to:
 ```xml
 <PackageReference Include="Backport.System.Threading.Lock" Version="3.0.3">
   <PrivateAssets>all</PrivateAssets>
-  <ExcludeAssets>compile;runtime</ExcludeAssets>
   <IncludeAssets>analyzers</IncludeAssets>
 </PackageReference>
 ```
@@ -161,7 +160,6 @@ Therefore in the clean method (if only targeting .NET 5.0 or greater):
 ```xml
 <PackageReference Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Include="Backport.System.Threading.Lock" Version="3.0.3">
   <PrivateAssets>all</PrivateAssets>
-  <ExcludeAssets>compile;runtime</ExcludeAssets>
   <IncludeAssets>analyzers</IncludeAssets>
 </PackageReference>
 ```
@@ -172,7 +170,6 @@ and in the factory method (if targeting frameworks prior to .NET 5.0):
 <ItemGroup>
   <PackageReference Include="Backport.System.Threading.Lock" Version="3.0.3">
     <PrivateAssets>all</PrivateAssets>
-    <ExcludeAssets>compile;runtime</ExcludeAssets>
     <IncludeAssets>analyzers</IncludeAssets>
   </PackageReference>
   <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ to:
 ```xml
 <PackageReference Include="Backport.System.Threading.Lock" Version="3.0.3">
   <PrivateAssets>all</PrivateAssets>
+  <ExcludeAssets>compile;runtime</ExcludeAssets>
   <IncludeAssets>analyzers</IncludeAssets>
 </PackageReference>
 ```
@@ -160,6 +161,7 @@ Therefore in the clean method (if only targeting .NET 5.0 or greater):
 ```xml
 <PackageReference Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Include="Backport.System.Threading.Lock" Version="3.0.3">
   <PrivateAssets>all</PrivateAssets>
+  <ExcludeAssets>compile;runtime</ExcludeAssets>
   <IncludeAssets>analyzers</IncludeAssets>
 </PackageReference>
 ```
@@ -170,6 +172,7 @@ and in the factory method (if targeting frameworks prior to .NET 5.0):
 <ItemGroup>
   <PackageReference Include="Backport.System.Threading.Lock" Version="3.0.3">
     <PrivateAssets>all</PrivateAssets>
+    <ExcludeAssets>compile;runtime</ExcludeAssets>
     <IncludeAssets>analyzers</IncludeAssets>
   </PackageReference>
   <Using Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))" Alias="Lock" Include="System.Threading.Lock" />


### PR DESCRIPTION
Closes #4 

### Changes
- Source generators no longer run if `Backport.System.Threading.Lock` is referenced during compilation.

### Notes
- I didn't bump the versions yet, since I'm not sure what your preferred way of working is in that regard.
